### PR TITLE
Os agnostic local paths

### DIFF
--- a/kavita_create_library_per_folder.py
+++ b/kavita_create_library_per_folder.py
@@ -131,7 +131,7 @@ def main():
 
     parser.add_argument('-p', '--path', type=str, required=False, help='Path to your folders')
 
-    parser.add_argument('-lt', '--library-type', type=int, required=False, choices=range(0, 5),
+    parser.add_argument('-lt', '--library-type', type=int, required=False, choices=range(0, 6),
                         help='What type of library is this? 0 = Manga, 1 = Comics, 2 = Books (epubs), 3 = Loose '
                              'Images, 4 = Light Novels, 5 = Comics(ComicVine)')
 

--- a/kavita_create_library_per_folder.py
+++ b/kavita_create_library_per_folder.py
@@ -50,14 +50,9 @@ def authenticate(url):
         exit()
 
 
-def get_docker_path(win_path, docker_path):
-    win_path_parts = win_path.split('\\')
-
-    publisher_folder = win_path_parts[-1]
-
+def get_docker_path(local_path, docker_path):
+    publisher_folder = os.path.split(local_path)[-1]
     docker_path = os.path.join(docker_path, publisher_folder)
-    docker_path = docker_path.replace('\\', '/')
-
     return docker_path
 
 


### PR DESCRIPTION
Cool little script! A couple small fixes I had to make to get it to work for me.

Getting the docker path when the local path/host is linux can be easily done w/ `os.path.split()` function. No need to replace either as the `.split` function gives the last component of the path (and should expect the `docker_path` to be a `/` path).

Also the `range()` function parameter for the upper limit is exclusive... so `range(0,5)` gives you `(0,1,2,3,4)` only. To support ComicVine, I had to bump it to 5.

Feel free to merge if you'd like or make any edits.